### PR TITLE
マナ総量で検索可能にする

### DIFF
--- a/src/lib/fetchCards.ts
+++ b/src/lib/fetchCards.ts
@@ -4,10 +4,9 @@ const API_URL = 'https://api.scryfall.com';
 
 export async function fetchRandomCardFromAPI(query: string): Promise<Card | null> {
   try {
-    const res = await fetch(`${API_URL}/cards/random?q=${encodeURIComponent(query)}`);
+    const res = await fetch(`${API_URL}/cards/random?q=${query}`);
     if (!res.ok) throw new Error('API response not ok');
-    const data: Card = await res.json();
-    return data;
+    return await res.json();
   } catch (error) {
     console.error('Error fetching card:', error);
     return null;


### PR DESCRIPTION
## 背景
- https://github.com/Shade4827/mtg-momir-web/issues/11
- https://github.com/Shade4827/mtg-momir-web/issues/9

## 対応内容
- マナ総量の入力フォームを追加
- 検索ボタンを追加

▼検索前
<img width="420" height="169" alt="スクリーンショット 2025-08-17 15 18 54" src="https://github.com/user-attachments/assets/b01ed38c-5aa8-4b99-ad69-a28baae4579b" />

▼検索後
<img width="361" height="451" alt="スクリーンショット 2025-08-17 15 19 30" src="https://github.com/user-attachments/assets/0741c480-6fea-4d6e-b66e-28255faa4857" />

