### PR TITLE
抽選結果に出るカードを制限する

### DIFF
--- a/src/lib/Card.ts
+++ b/src/lib/Card.ts
@@ -5,6 +5,7 @@ export interface Card {
   multiverse_ids: number[];
   arena_id?: number;
   name: string;
+  printed_name?: string;
   lang: string;
   released_at: string;
   uri: string;
@@ -23,12 +24,15 @@ export interface Card {
   mana_cost?: string;
   cmc?: number;
   type_line: string;
+  printed_type_line?: string;
   oracle_text?: string;
+  printed_text?: string;
   power?: string;
   toughness?: string;
   colors?: string[];
   color_identity?: string[];
   keywords?: string[];
+  produced_mana?: string[];
   all_parts?: Array<{
     object: string;
     id: string;
@@ -60,6 +64,7 @@ export interface Card {
   collector_number?: string;
   digital?: boolean;
   rarity: string;
+  flavor_text?: string;
   card_back_id?: string;
   artist?: string;
   artist_ids?: string[];
@@ -71,7 +76,10 @@ export interface Card {
   textless?: boolean;
   booster?: boolean;
   story_spotlight?: boolean;
+  edhrec_rank?: number;
+  penny_rank?: number;
   promo_types?: string[];
   prices?: { [key: string]: string | null };
   related_uris?: { [key: string]: string };
+  purchase_uris?: { [key: string]: string };
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,7 +47,7 @@
   <ul>
     <li style="margin-bottom: 1em;">
       <strong>{card.cmc}</strong>
-      <strong>{card.name}</strong><br />
+      <strong>{card.printed_name}</strong><br />
       <a href={card.scryfall_uri} target="_blank" rel="noopener noreferrer">
         {#if card.image_uris}
           <img src={card.image_uris.normal} alt={card.name} />


### PR DESCRIPTION
## 背景
- https://github.com/Shade4827/mtg-momir-web/issues/14

## 対応内容
- 検索クエリを追加
  - 日本語版カード・ページを出す
  - 紙で出ているカードのみ
- カードを取得できなかった場合にエラーメッセージを表示

Closes #14 

▼日本語のカードが表示される
<img width="527" height="767" alt="スクリーンショット 2025-08-17 17 50 32" src="https://github.com/user-attachments/assets/12c86bf5-cfd2-4374-85ff-729aa2db007d" />

▼14など存在しないマナ総量のカードはエラー文言が表示される
<img width="515" height="797" alt="スクリーンショット 2025-08-17 17 51 26" src="https://github.com/user-attachments/assets/693e1652-abe1-4a35-aa83-e935a00733ac" />

▼日本語版のないカードも表示される
<img width="517" height="770" alt="スクリーンショット 2025-08-17 17 49 31" src="https://github.com/user-attachments/assets/22918646-79b1-43b8-8190-6da12ebdac7d" />
