### PR TITLE
Show past cards

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,6 +47,12 @@
     currentCard = result;
     saving = false;
   }
+
+  const reset = () => {
+    currentCard = null;
+    pastCards = [];
+    manaValue = null;
+  };
 </script>
 
 {#if errorMessage}
@@ -77,6 +83,8 @@
 <button on:click={getCard} disabled={saving}>
   {saving ? '取得中...' : 'カードを取得'}
 </button>
+
+<button on:click={reset}>リセット</button>
 
 <h2>過去のカード</h2>
 <ul>


### PR DESCRIPTION
## 背景
- https://github.com/Shade4827/mtg-momir-web/issues/12

## 対応内容
- 過去のカード一覧を表示
- リセットボタンを追加

Closes #12

<img width="2940" height="2496" alt="localhost-5173-08-17-2025_08_13_PM" src="https://github.com/user-attachments/assets/2f237e52-4de0-430d-8373-1707390cd3bd" />
