### PR TITLE
Set style

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,7 +88,7 @@
     </div>
     {#if currentCard.image_uris}
       <a href={currentCard.scryfall_uri} target="_blank" rel="noopener noreferrer">
-        <img src={currentCard.image_uris.normal} alt={currentCard.name} />
+        <img src={currentCard.image_uris.normal} alt={currentCard.name} class="w-108 h-auto" />
       </a>
     {/if}
   {:else}
@@ -131,12 +131,10 @@
   <ul class="space-y-4 overflow-y-auto flex-1">
     {#each pastCards as pastCard (pastCard.id)}
       <li>
-        <strong class="text-blue-700">{pastCard.cmc}:</strong>
         <strong class="text-gray-900 truncate block max-w-[13rem]">{pastCard.printed_name}</strong>
-        <br />
         {#if pastCard.image_uris}
           <a href={pastCard.scryfall_uri} target="_blank" rel="noopener noreferrer">
-            <img src={pastCard.image_uris.small} alt={pastCard.name} class="mx-auto" />
+            <img src={pastCard.image_uris.small} alt={pastCard.name} class="mx-auto w-28 h-auto" />
           </a>
         {/if}
       </li>


### PR DESCRIPTION
## 背景
- https://github.com/Shade4827/mtg-momir-web/issues/17

## 対応内容
- 全体的なスタイルを調整
  - カードなどメインのUIを中央寄せにする
  - 過去に抽選されたカード一覧を右側に縦方向に表示
- ヘッダーを追加

Closes #17 

<img width="1470" height="797" alt="スクリーンショット 2025-08-18 20 00 21" src="https://github.com/user-attachments/assets/9a44d1cc-6bed-4e07-ae49-337ab9cd30e2" />
