### PR TITLE
Responsive

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -152,7 +152,7 @@
 
 <!-- PC: 右側サイドバー（常時表示） -->
 <div
-  class="hidden sm:flex fixed top-20 right-0 w-64 md:w-80 h-[calc(100vh-5rem)] bg-white shadow-lg border-l border-gray-200 flex-col z-40"
+  class="hidden lg:flex fixed top-20 right-0 w-64 h-[calc(100vh-5rem)] bg-white shadow-lg border-l border-gray-200 flex-col z-40"
 >
   <div class="p-4 flex flex-col h-full">
     <h2 class="text-lg font-bold mb-2 flex-shrink-0">抽選済み</h2>
@@ -169,8 +169,8 @@
   </div>
 </div>
 
-<!-- モバイル: 右側サイドバー（開閉可能・アイコンのみ/展開時は現状幅） -->
-<div class="sm:hidden z-40">
+<!-- モバイル・タブレット: 右側サイドバー（開閉可能・アイコンのみ/展開時は現状幅） -->
+<div class="xl:hidden z-40">
   {#if !sidebarOpen}
     <button
       class="fixed bottom-4 right-4 w-14 h-14 bg-blue-500 text-white flex items-center justify-center rounded-full shadow-lg border-2 border-blue-600"


### PR DESCRIPTION
## 背景
- https://github.com/Shade4827/mtg-momir-web/issues/22

## 対応内容
- モバイルとタブレットサイズのレスポンシブ対応
  - モバイル・タブレットの場合は抽選済みカードを開閉可能にする
- 同じカードが2連続で抽選される場合エラーになるのを修正

▼モバイル
<img width="530" height="793" alt="スクリーンショット 2025-08-19 22 08 49" src="https://github.com/user-attachments/assets/e782e090-243d-4729-90b3-e117e9fcfffe" />

▼タブレット
<img width="603" height="793" alt="スクリーンショット 2025-08-19 22 08 56" src="https://github.com/user-attachments/assets/297f82be-2bc9-40fc-889a-794c70784ada" />

▼抽選済みカードを開いた状態
<img width="627" height="795" alt="スクリーンショット 2025-08-19 22 09 01" src="https://github.com/user-attachments/assets/ed6a32c7-e86d-4543-9eac-631ca36ab12b" />

Closes #22