### PR TITLE
エラー発生時にカード画像を薄くしないようにする

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -112,7 +112,7 @@
       <img
         src={currentCard.imageNormal}
         alt={currentCard.name}
-        class={`w-96 max-w-xs sm:max-w-md md:max-w-lg h-auto`}
+        class="w-96 max-w-xs sm:max-w-md md:max-w-lg h-auto"
       />
     </a>
   {:else}


### PR DESCRIPTION
## 背景
- https://github.com/Shade4827/mtg-momir-web/issues/26

## 対応内容
- エラー発生時にカード画像を薄くするクラスの適用をやめる

<img width="1139" height="794" alt="スクリーンショット 2025-08-20 16 53 00" src="https://github.com/user-attachments/assets/762d842c-6051-41c7-9267-218331eab125" />

Closes #26