### PR TITLE
合体カードを表示されないようにする

### DIFF
--- a/src/lib/Card.ts
+++ b/src/lib/Card.ts
@@ -1,6 +1,7 @@
 export interface ScryfallCardResponse {
   id: string;
   printed_name?: string;
+  mana_cost?: string;
   cmc?: number;
   image_uris?: {
     normal?: string;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,6 +47,12 @@
       return;
     }
 
+    if (!result.mana_cost) {
+      errorMessage = '合体カードのため、再度お試しください。';
+      saving = false;
+      return;
+    }
+
     const displayCard = toDisplayCard(result);
     if (!displayCard) {
       errorMessage = '表面がクリーチャーでないカードのため、再度お試しください。';


### PR DESCRIPTION
## 背景
- https://github.com/Shade4827/MomirDraw/issues/33

## 対応内容
- 合体カードが抽選されないように修正

Closes https://github.com/Shade4827/MomirDraw/issues/33