### PR TITLE
検索クエリをリセットするように修正

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -34,7 +34,7 @@
   }
 
   const buildQuery = (): string => {
-    let queryParts = BASE_QUERY_PARTS;
+    const queryParts = [...BASE_QUERY_PARTS];
 
     if (isValidMana) {
       queryParts.push(`cmc=${manaValue}`);


### PR DESCRIPTION
## 背景
検索を2回行うとマナ総量とレアリティに関する検索クエリがその都度増えていて正しい検索ができていなかった

## 対応内容
- 配列を代入するのではなく、コピーを作成するように修正